### PR TITLE
fix parsing project config missing value

### DIFF
--- a/internal/config/projectconfig/project_config.go
+++ b/internal/config/projectconfig/project_config.go
@@ -14,7 +14,7 @@ const GraphRootName = "graphRoot"
 
 type ZeroProjectConfig struct {
 	Name                   string `yaml:"name"`
-	ShouldPushRepositories bool
+	ShouldPushRepositories bool   `yaml:"shouldPushRepositories"`
 	Parameters             map[string]string
 	Modules                Modules `yaml:"modules"`
 }

--- a/internal/config/projectconfig/project_config_test.go
+++ b/internal/config/projectconfig/project_config_test.go
@@ -24,8 +24,9 @@ func TestLoadConfig(t *testing.T) {
 	filePath := file.Name()
 
 	want := &projectconfig.ZeroProjectConfig{
-		Name:    "abc",
-		Modules: eksGoReactSampleModules(),
+		Name:                   "abc",
+		ShouldPushRepositories: true,
+		Modules:                eksGoReactSampleModules(),
 	}
 
 	t.Run("Should load and unmarshal config correctly", func(t *testing.T) {
@@ -34,7 +35,6 @@ func TestLoadConfig(t *testing.T) {
 			t.Errorf("projectconfig.ZeroProjectConfig.Unmarshal mismatch (-want +got):\n%s", cmp.Diff(want, got))
 		}
 	})
-
 }
 
 func eksGoReactSampleModules() projectconfig.Modules {
@@ -51,7 +51,7 @@ func validConfigContent() string {
 # Templated zero-project.yml file
 name: abc
 
-shouldPushRepositories: false
+shouldPushRepositories: true
 
 modules:
   aws-eks-stack:


### PR DESCRIPTION
shouldPushRepositories flag was defaulting to false, so didn't realize the flag from yml file wasn't parsed 
and test case was expecting the default case, so didn't catch this