### PR TITLE
zero-234 Image Hosting Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.30.12
 	github.com/coreos/go-semver v0.2.0
+	github.com/gabriel-vasile/mimetype v1.1.1
 	github.com/google/go-cmp v0.3.1
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-getter v1.4.2-0.20200106182914-9813cbd4eb02
@@ -28,6 +29,5 @@ require (
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.2.2
-	github.com/gabriel-vasile/mimetype v1.1.1
 
 )

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -19,6 +19,15 @@ func GetRegistry() Registry {
 			},
 		},
 		{
+			"EKS + NodeJS + React + Gatsby",
+			[]string{
+				"github.com/commitdev/zero-aws-eks-stack",
+				"github.com/commitdev/zero-deployable-landing-page",
+				"github.com/commitdev/zero-deployable-node-backend",
+				"github.com/commitdev/zero-deployable-react-frontend",
+			},
+		},
+		{
 			"Custom", []string{},
 		},
 	}


### PR DESCRIPTION
https://app.zenhub.com/workspaces/commit-zero-5da8decc7046a60001c6db44/issues/commitdev/zero/234

Adds new selectable backend stack with NodeJS support.