### PR TITLE
Allow specifying local module paths in the init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ We are using a tool called `goreleaser` which you can get from brew if you're on
 After you have the tool, you can follow these steps:
 ```
 export GITHUB_TOKEN=<your token with access to write to the zero repo>
-git tag -a <version number like v0.0.1> -m "Some message about this release"
+git tag -s -a <version number like v0.0.1> -m "Some message about this release"
 git push origin <version number>
 goreleaser release
 ```

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,7 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var localModulePath string
+
 func init() {
+	initCmd.PersistentFlags().StringVarP(&localModulePath, "local-module-path", "m", "github.com/commitdev", "local module path - for using local modules instead of downloading from github")
 	rootCmd.AddCommand(initCmd)
 }
 
@@ -19,7 +22,7 @@ var initCmd = &cobra.Command{
 	Short: "Create new project with provided name and initialize configuration based on user input.",
 	Run: func(cmd *cobra.Command, args []string) {
 		flog.Debugf("Root directory is %s", projectconfig.RootDir)
-		projectContext := initPrompts.Init(projectconfig.RootDir)
+		projectContext := initPrompts.Init(projectconfig.RootDir, localModulePath)
 		projectConfigErr := projectconfig.CreateProjectConfigFile(projectconfig.RootDir, projectContext.Name, projectContext)
 
 		if projectConfigErr != nil {

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Create cloud provider context
-func Init(outDir string) *projectconfig.ZeroProjectConfig {
+func Init(outDir string, localModulePath string) *projectconfig.ZeroProjectConfig {
 	projectConfig := defaultProjConfig()
 
 	projectConfig.Name = getProjectNamePrompt().GetParam(projectConfig.Parameters)
@@ -34,7 +34,7 @@ func Init(outDir string) *projectconfig.ZeroProjectConfig {
 		exit.Fatal("Error creating root: %v ", err)
 	}
 
-	moduleSources := chooseStack(registry.GetRegistry())
+	moduleSources := chooseStack(registry.GetRegistry(localModulePath))
 	moduleConfigs, mappedSources := loadAllModules(moduleSources)
 
 	prompts := getProjectPrompts(projectConfig.Name, moduleConfigs)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -6,25 +6,25 @@ type Stack struct {
 	ModuleSources []string
 }
 
-func GetRegistry() Registry {
+func GetRegistry(path string) Registry {
 	return Registry{
 		// TODO: better place to store these options as configuration file or any source
 		{
 			"EKS + Go + React + Gatsby",
 			[]string{
-				"github.com/commitdev/zero-aws-eks-stack",
-				"github.com/commitdev/zero-deployable-landing-page",
-				"github.com/commitdev/zero-deployable-backend",
-				"github.com/commitdev/zero-deployable-react-frontend",
+				path+"/zero-aws-eks-stack",
+				path+"/zero-deployable-landing-page",
+				path+"/zero-deployable-backend",
+				path+"/zero-deployable-react-frontend",
 			},
 		},
 		{
 			"EKS + NodeJS + React + Gatsby",
 			[]string{
-				"github.com/commitdev/zero-aws-eks-stack",
-				"github.com/commitdev/zero-deployable-landing-page",
-				"github.com/commitdev/zero-deployable-node-backend",
-				"github.com/commitdev/zero-deployable-react-frontend",
+				path+"/zero-aws-eks-stack",
+				path+"/zero-deployable-landing-page",
+				path+"/zero-deployable-node-backend",
+				path+"/zero-deployable-react-frontend",
 			},
 		},
 		{


### PR DESCRIPTION
To make it a little easier to work with local modules.
Eventually we will likely have a better solution for this as we dig more into the module ecosystem / registry idea, but for now this is a quick way to make it more flexible.