### PR TITLE
bug: remove applying stage & prod at the same time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 
 )
+
+// Tencent cloud unpublished their version v3.0.82 and became v1.0.191
+// https://github.com/hashicorp/terraform/issues/29021
+replace github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible => github.com/tencentcloud/tencentcloud-sdk-go v1.0.191

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,3 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 
 )
-
-// Tencent cloud unpublished their version v3.0.82 and became v1.0.191
-// https://github.com/hashicorp/terraform/issues/29021
-replace github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible => github.com/tencentcloud/tencentcloud-sdk-go v1.0.191

--- a/go.sum
+++ b/go.sum
@@ -368,6 +368,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
+github.com/tencentcloud/tencentcloud-sdk-go v1.0.191/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
 github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae h1:vgGSvdW5Lqg+I1aZOlG32uyE6xHpLdKhZzcTEktz5wM=

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -167,12 +167,11 @@ func getModuleOperationCommand(mod moduleconfig.ModuleConfig, operation string) 
 // promptEnvironments Prompts the user for the environments to apply against and returns a slice of strings representing the environments
 func promptEnvironments() []string {
 	items := map[string][]string{
-		"Staging":                     {"stage"},
-		"Production":                  {"prod"},
-		"Both Staging and Production": {"stage", "prod"},
+		"Staging":    {"stage"},
+		"Production": {"prod"},
 	}
 
-	labels := []string{"Staging", "Production", "Both Staging and Production"}
+	labels := []string{"Staging", "Production"}
 
 	providerPrompt := promptui.Select{
 		Label: "Environments",


### PR DESCRIPTION
in many places in templates we use var.enviroment, which means
it will template out resources name such as `project-stage,prod-db`
and theres not too much value in doing both at the same time as of now