### PR TITLE
fix: missing projectName context in prompt:execute

### DIFF
--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -51,7 +51,7 @@ func Init(outDir string, localModulePath string) *projectconfig.ZeroProjectConfi
 	// Prompting for push-up stream, then conditionally prompting for github
 	prompts["GithubRootOrg"].RunPrompt(initParams, emptyEnvVarTranslationMap)
 
-	projectData := promptAllModules(moduleConfigs)
+	projectData := promptAllModules(moduleConfigs, &projectConfig)
 
 	// Map parameter values back to specific modules
 	for moduleName, module := range moduleConfigs {

--- a/internal/init/prompts.go
+++ b/internal/init/prompts.go
@@ -11,6 +11,7 @@ import (
 
 	tm "github.com/buger/goterm"
 	"github.com/commitdev/zero/internal/config/moduleconfig"
+	"github.com/commitdev/zero/internal/config/projectconfig"
 	"github.com/commitdev/zero/internal/constants"
 	"github.com/commitdev/zero/internal/util"
 	"github.com/commitdev/zero/pkg/util/exit"
@@ -276,8 +277,8 @@ func PromptModuleParams(moduleConfig moduleconfig.ModuleConfig, parameters map[s
 // promptAllModules takes a map of all the modules and prompts the user for values for all the parameters
 // Important: This is done here because in this step we share the parameter across modules,
 // meaning if module A and B both asks for region, it will reuse the response for both (and is deduped during runtime)
-func promptAllModules(modules map[string]moduleconfig.ModuleConfig) map[string]string {
-	parameterValues := map[string]string{}
+func promptAllModules(modules map[string]moduleconfig.ModuleConfig, projectConfig *projectconfig.ZeroProjectConfig) map[string]string {
+	parameterValues := availableProjectContext(projectConfig)
 	for _, config := range modules {
 		var err error
 
@@ -287,6 +288,13 @@ func promptAllModules(modules map[string]moduleconfig.ModuleConfig) map[string]s
 		}
 	}
 	return parameterValues
+}
+
+// availableProjectContext declares a list of variables usable in modules parameter prompt's execute step
+func availableProjectContext(projectConfig *projectconfig.ZeroProjectConfig) map[string]string {
+	return map[string]string{
+		"projectName": projectConfig.Name,
+	}
 }
 
 func paramConditionsMapper(conditions []moduleconfig.Condition) CustomConditionSignature {


### PR DESCRIPTION
reference in modules for `projectName` doesn't work anymore in places like https://github.com/commitdev/zero-backend-node/blob/8db8db64bce4d7772ea6de2d235aebe97edc5c2a/zero-module.yml#L127-L128


Looks like used to be appended from the [`projectCredentials`](https://github.com/commitdev/zero/commit/7f4c7a34a21426df0b09e1018bce4f05ed468150#diff-e1c5b6a139d58abff4f87ec5e4598a25b582dc09de7a2743649868f3bc9e5b34L124)