### PR TITLE
refactor: print nicer error to load config error

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/zero.iml" filepath="$PROJECT_DIR$/.idea/zero.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectViewState">
-    <option name="hideEmptyMiddlePackages" value="true" />
-    <option name="showLibraryContents" value="true" />
-  </component>
-</project>

--- a/.idea/zero.iml
+++ b/.idea/zero.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="Go" enabled="true" />
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
> https://github.com/commitdev/zero/blob/0c9bf0c9442cc0ec3319f88cbffdd7d4c8d687b5/internal/config/projectconfig/project_config.go#L70-L74
> 
> 
> This is a fairly common failure case and it should be pretty obvious to the user how to resolve it, there's no need for the stack trace we get with `log.Panicf`, let's use `exit.Fatal` instead.

