### PR TITLE
Fix: Use correct github actions page url

### DIFF
--- a/doc-site/src/components/HomepageOfferings.js
+++ b/doc-site/src/components/HomepageOfferings.js
@@ -57,7 +57,7 @@ const offerings = [
         name: 'Github Actions',
         logo: 'img/tools/github-actions.svg',
         noCrop: true,
-        url: 'https://google.ca',
+        url: 'https://github.com/features/actions',
       },
       {
         name: 'CircleCI',


### PR DESCRIPTION
Noticed github actions url was pointing to https://google.ca. This fixes it :)