### PR TITLE
add docker cli as a requirement during check

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -120,6 +120,14 @@ var checkCmd = &cobra.Command{
 				docsURL:    "https://kubernetes.io/docs/tasks/tools/install-kubectl/",
 			},
 			{
+				name:       "Docker\t\t",
+				command:    "docker",
+				args:       []string{"--version"},
+				regexStr:   `Docker version (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*), build ([a-f0-9]{7})`,
+				minVersion: "18.0.0",
+				docsURL:    "https://docs.docker.com/get-docker/",
+			},
+			{
 				name:       "Terraform\t",
 				command:    "terraform",
 				args:       []string{"version"},


### PR DESCRIPTION
Docker does not officially provide LTS versions, picked 18.0.0 as a
baseline because it seems like a reasonable timeframe(2018), appears
they are already out of support cycle. I think we should encourage
but not enforce using newer versions that receives security updates. any thoughts? 