### PR TITLE
trim git.defaultBranch linebreak from cmd output

### DIFF
--- a/internal/vcs/create-git-repos.go
+++ b/internal/vcs/create-git-repos.go
@@ -165,7 +165,8 @@ func getInitDefaultBranch() string {
 		return "main"
 	}
 
-	return string(output)
+	branchName := strings.TrimSuffix(string(output), "\n")
+	return branchName
 }
 
 // doInitialCommit runs the git commands that initialize and do the first commit to a repository.


### PR DESCRIPTION
git cli returning configs will add a newline for printing purposes, this trims it so it doesn't go into our commands 